### PR TITLE
Update web_page_oauth2.ex

### DIFF
--- a/lib/wechat/plug/web_page_oauth2.ex
+++ b/lib/wechat/plug/web_page_oauth2.ex
@@ -208,7 +208,7 @@ if Code.ensure_loaded?(Plug) do
             {String.trim_trailing(request_url, "/"), ""}
 
           path ->
-            path = Path.join(path, "/")
+            path = Enum.join(path, "/")
 
             prefix_path = request_url |> String.trim_trailing("/") |> String.trim_trailing(path)
 


### PR DESCRIPTION
Path.join/2 用于了链接两个路径， 第二个参数并不是分割符