### PR TITLE
fix some bugs

### DIFF
--- a/lib/wechat/plug/event_handler.ex
+++ b/lib/wechat/plug/event_handler.ex
@@ -97,7 +97,7 @@ if Code.ensure_loaded?(Plug) do
 
       event_parser =
         case Map.fetch(opts, :event_parser) do
-          {:ok, parser} when is_function(parser, 4) ->
+          {:ok, parser} when is_function(parser, 3) ->
             parser
 
           {:ok, :auto} ->

--- a/lib/wechat/refresher/default.ex
+++ b/lib/wechat/refresher/default.ex
@@ -357,6 +357,27 @@ defmodule WeChat.Refresher.Default do
     end
   end
 
+  def ensure_authorizer_refresh_token(client) do
+    appid = client.appid()
+    store_id = appid
+    store_key = :authorizer_refresh_token
+    case restore_and_cache(store_id, store_key, client) do
+      false ->
+        Logger.error(
+          "Attention: #{inspect(appid)}'s authorizer_refresh_token is expired because it has not been refreshed for too long, you can use api_get_authorizer_list API to refresh it"
+        )
+
+        {:error, "authorizer_refresh_token expired"}
+
+      {true, _expires_in} ->
+        Logger.info(
+          "Restore #{inspect(appid)}'s authorizer_refresh_token succeed."
+        )
+
+        :ok
+    end
+  end
+
   defp init_client_options(client, options) do
     Logger.info(
       "Initialize WeChat Client: #{inspect(client)} by AppType: #{client.app_type()}, Storage: #{inspect(client.storage())}."

--- a/lib/wechat/refresher/default.ex
+++ b/lib/wechat/refresher/default.ex
@@ -281,7 +281,7 @@ defmodule WeChat.Refresher.Default do
   @impl true
   def handle_cast({:refresh_key, client, store_id, store_key, value, expires}, state) do
     cache_and_store(store_id, store_key, value, expires, client)
-    {:ok, state}
+    {:noreply, state}
   end
 
   @impl true

--- a/lib/wechat/refresher/default_settings.ex
+++ b/lib/wechat/refresher/default_settings.ex
@@ -5,6 +5,7 @@ defmodule WeChat.Refresher.DefaultSettings do
 
   require Logger
   alias WeChat.{Account, WebPage, Component, MiniProgram, Work, Utils, Storage.Cache}
+  alias WeChat.Refresher.Default
 
   @type key_name :: atom
   @type token :: String.t()
@@ -236,6 +237,7 @@ defmodule WeChat.Refresher.DefaultSettings do
   @spec refresh_authorizer_access_token(WeChat.client()) :: refresh_fun_result
   def refresh_authorizer_access_token(client) do
     with :ignore <- get_token_for_hub_client(client, :access_token),
+         :ok <- Default.ensure_authorizer_refresh_token(client),
          {:ok, %{status: 200, body: data}} <- Component.authorizer_token(client),
          %{
            "authorizer_access_token" => authorizer_access_token,

--- a/lib/wechat/server_message/event_helper.ex
+++ b/lib/wechat/server_message/event_helper.ex
@@ -243,7 +243,11 @@ if Code.ensure_loaded?(Plug) do
     @spec decrypt_xml_msg(encrypt_content, params, WeChat.client()) ::
             {:ok, :encrypted, xml_string} | {:error, String.t()}
     def decrypt_xml_msg(encrypt_content, params, client) do
-      decrypt_xml_msg(encrypt_content, params, client.appid(), client.token(), client.aes_key())
+      if client.by_component? do
+        decrypt_xml_msg(encrypt_content, params, client.component_appid(), client.token(), client.aes_key())
+      else
+        decrypt_xml_msg(encrypt_content, params, client.appid(), client.token(), client.aes_key())
+      end
     end
 
     @spec decrypt_xml_msg(
@@ -288,12 +292,20 @@ if Code.ensure_loaded?(Plug) do
 
     @spec encrypt_xml_msg(xml_string, timestamp, WeChat.client()) :: String.t()
     def encrypt_xml_msg(xml_string, timestamp, client) do
-      encrypt_xml_msg(xml_string, timestamp, client.appid(), client.token(), client.aes_key())
+      if client.by_component? do
+        encrypt_xml_msg(xml_string, timestamp, client.component_appid(), client.token(), client.aes_key())
+      else
+        encrypt_xml_msg(xml_string, timestamp, client.appid(), client.token(), client.aes_key())
+      end
     end
 
     @spec encrypt_xml_msg(xml_string, timestamp, WeChat.client(), Work.Agent.t()) :: String.t()
     def encrypt_xml_msg(xml_string, timestamp, client, agent) do
-      encrypt_xml_msg(xml_string, timestamp, client.appid(), agent.token, agent.aes_key)
+      if client.by_component? do
+        encrypt_xml_msg(xml_string, timestamp, client.component_appid(), agent.token, agent.aes_key)
+      else
+        encrypt_xml_msg(xml_string, timestamp, client.appid(), agent.token, agent.aes_key)
+      end
     end
 
     @spec encrypt_xml_msg(

--- a/lib/wechat/server_message/reply_message.ex
+++ b/lib/wechat/server_message/reply_message.ex
@@ -41,7 +41,7 @@ defmodule WeChat.ServerMessage.ReplyMessage do
     <ToUserName><![CDATA[toUser]]></ToUserName>
     <FromUserName><![CDATA[fromUser]]></FromUserName>
     <CreateTime>12345678</CreateTime>
-    <MsgType>text></MsgType>
+    <MsgType><![CDATA[text]]></MsgType>
     <Content><![CDATA[你好]]></Content>
   </xml>
   ```
@@ -52,7 +52,7 @@ defmodule WeChat.ServerMessage.ReplyMessage do
       <ToUserName><![CDATA[<%= to_openid %>]]></ToUserName>
       <FromUserName><![CDATA[<%= from_wx_no %>]]></FromUserName>
       <CreateTime><%= timestamp %></CreateTime>
-      <MsgType>text</MsgType>
+      <MsgType><![CDATA[text]]></MsgType>
       <Content><![CDATA[<%= content %>]]></Content>
     </xml>
     """


### PR DESCRIPTION
Hi, feng19, when I use the wechat sdk I found some bugs: 

1. the number of parameters of event_parser function should be 3.
2. the return value of handle_cast should be :noreply
3. when refreshing access_token by itself, should read authorizer_refresh_token from wechat_app_tokens.json to the cache
4. reply text message format with a bit of error
5. should comaptible with third-party platforms when decrypt / encrypt xml massage

the above modification has been tested by myself. Please let me know if I'm wrong, thanks so much.